### PR TITLE
Fixed consul execution. Missed "agent" keyword in previous PR

### DIFF
--- a/docker-files/Dockerfile.aarch64
+++ b/docker-files/Dockerfile.aarch64
@@ -64,6 +64,7 @@ ENV WAIT_FOR_A_WHILE=10
 
 ENV CONSUL_ARGS="-server -client=0.0.0.0 -bootstrap -ui"
 
+ENV ARCH=arm64
 
 #copy JAR and default config files to the image
 COPY --from=0 *.jar $APP_DIR/$APP

--- a/docker-files/launch-consul-config.sh
+++ b/docker-files/launch-consul-config.sh
@@ -18,7 +18,12 @@
 
 set -e
 
-rm -rf /consul/data/* && $APP_DIR/docker-entrypoint.sh $CONSUL_ARGS | tee /edgex/logs/core-consul.log
+if [ -z $ARCH ]
+	then
+	rm -rf /consul/data/* && docker-entrypoint.sh agent $CONSUL_ARGS | tee /edgex/logs/core-consul.log
+else
+	rm -rf /consul/data/* && $APP_DIR/docker-entrypoint.sh agent $CONSUL_ARGS | tee /edgex/logs/core-consul.log
+fi
 
 echo "Waiting for $WAIT_FOR_A_WHILE seconds until consul is configured"
 sleep $WAIT_FOR_A_WHILE

--- a/docker-files/launch-consul-config.sh
+++ b/docker-files/launch-consul-config.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 # Copyright 2017 Cavium Inc.
 #


### PR DESCRIPTION
Also, as non-arm64 docker is launching script from a distinct path, need to know the arch. I have added a variable to use the same wrapper script.

And it seems that shebang was wrong.